### PR TITLE
add -std=gnu++11 flag to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 CC = g++
 EXE = dots
 # compiler args
-COMPARGS = -Wall -Wextra
+COMPARGS = -Wall -Wextra -std=gnu++11
 LINKARGS = -lncurses
 # directories
 SRC = src


### PR DESCRIPTION
I decided to try this out and it turns out that things are a lot easier for osx users when projects are compiled with the `-std=gnu++11` flag.

Once compiled, I have to say that the debugger was quite beautiful. Tbh, I'm quite jealous of the pretty unicode boxes separating the code from its output. The purple-ish color for asterisks was a nice touch, too.